### PR TITLE
Refactor: Unify page layouts with shared PageLayout component

### DIFF
--- a/src/app/bookmarks/[id]/page.tsx
+++ b/src/app/bookmarks/[id]/page.tsx
@@ -1,10 +1,14 @@
 import { notFound } from 'next/navigation';
 import { Suspense } from 'react';
+import Link from 'next/link';
 import { getBookmarkById } from '@/app/actions/bookmark-actions';
 import { BookmarkDetail } from '@/components/bookmark-detail';
 import { BookmarkMarkdown } from '@/components/bookmark-markdown';
 import { MarkdownSkeleton } from '@/components/markdown-skeleton';
 import { MarkdownRefreshButton } from '@/components/markdown-refresh-button';
+import { PageLayout } from '@/components/page-layout';
+import { Button } from '@/components/ui/button';
+import { Search, BarChart3 } from 'lucide-react';
 
 export default async function BookmarkDetailPage({
   params,
@@ -19,7 +23,26 @@ export default async function BookmarkDetailPage({
   }
 
   return (
-    <div className="container mx-auto px-4 py-8 max-w-6xl">
+    <PageLayout
+      title="Bookmark Details"
+      description={`Viewing bookmark for ${bookmark.entry.title}`}
+      actions={
+        <>
+          <Link href="/search">
+            <Button variant="outline" size="sm">
+              <Search className="h-4 w-4 mr-2" />
+              Search
+            </Button>
+          </Link>
+          <Link href="/stats">
+            <Button variant="outline" size="sm">
+              <BarChart3 className="h-4 w-4 mr-2" />
+              Stats
+            </Button>
+          </Link>
+        </>
+      }
+    >
       <Suspense fallback={<div>Loading...</div>}>
         <BookmarkDetail bookmark={bookmark} />
       </Suspense>
@@ -35,6 +58,6 @@ export default async function BookmarkDetailPage({
           <BookmarkMarkdown bookmarkId={bookmark.id} url={bookmark.url} />
         </Suspense>
       </div>
-    </div>
+    </PageLayout>
   );
 }

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -2,7 +2,7 @@ import { getBookmarks, getDomains, getTags } from '../actions/bookmark-actions';
 import { parseSearchParams, buildFiltersFromParams, buildSortFromParams } from '@/lib/search-params-schema';
 import { SearchForm } from '@/components/search-form';
 import { BookmarkList } from '@/components/bookmark-list';
-import { ThemeToggle } from '@/components/theme-toggle';
+import { PageLayout } from '@/components/page-layout';
 import { SearchPageClient } from '@/components/search-page-client';
 import { Suspense } from 'react';
 import Link from 'next/link';
@@ -44,61 +44,52 @@ export default async function SearchPage({
 
   return (
     <SearchPageClient>
-      <div className="flex flex-col gap-6 p-4 sm:p-6 lg:p-8 w-full">
-        <div className="flex items-center justify-between gap-2">
-          <div className="flex flex-col gap-1">
-            <h2 className="text-2xl font-semibold tracking-tight">
-              <Link href="/search" className="hover:underline">
-                Bookmark Search
-              </Link>
-            </h2>
-            <p className="text-muted-foreground">
-              Search and manage bookmarks with advanced filtering
-            </p>
-          </div>
-          <div className="flex items-center gap-2">
-            <Link href="/stats">
-              <Button variant="outline" size="sm">
-                <BarChart3 className="h-4 w-4 mr-2" />
-                Stats
-              </Button>
-            </Link>
-            <ThemeToggle />
-          </div>
+      <PageLayout
+        title={
+          <Link href="/search" className="hover:underline">
+            Bookmark Search
+          </Link>
+        }
+        description="Search and manage bookmarks with advanced filtering"
+        actions={
+          <Link href="/stats">
+            <Button variant="outline" size="sm">
+              <BarChart3 className="h-4 w-4 mr-2" />
+              Stats
+            </Button>
+          </Link>
+        }
+      >
+        <div className="flex items-center justify-between">
+          <SearchForm
+            domains={domains}
+            tags={tags}
+            initialValues={formValues}
+            bookmarks={bookmarksData.bookmarks}
+          />
         </div>
 
-        <div className="flex flex-col gap-4">
-          <div className="flex items-center justify-between">
-            <SearchForm
-              domains={domains}
-              tags={tags}
-              initialValues={formValues}
-              bookmarks={bookmarksData.bookmarks}
-            />
-          </div>
-
-          <Suspense fallback={
-            <div className="rounded-md border">
-              <div className="flex items-center justify-center h-24">
-                <div className="text-sm text-muted-foreground">Loading...</div>
-              </div>
+        <Suspense fallback={
+          <div className="rounded-md border">
+            <div className="flex items-center justify-center h-24">
+              <div className="text-sm text-muted-foreground">Loading...</div>
             </div>
-          }>
-            <BookmarkList
-              bookmarks={bookmarksData.bookmarks}
-              total={bookmarksData.total}
-              hasNextPage={bookmarksData.pagination.hasNextPage}
-              hasPreviousPage={bookmarksData.pagination.hasPreviousPage}
-              currentSort={sort}
-              currentFilters={{
-                domains: params.domains,
-                tags: params.tags,
-              }}
-              currentParams={rawParams}
-            />
-          </Suspense>
-        </div>
-      </div>
+          </div>
+        }>
+          <BookmarkList
+            bookmarks={bookmarksData.bookmarks}
+            total={bookmarksData.total}
+            hasNextPage={bookmarksData.pagination.hasNextPage}
+            hasPreviousPage={bookmarksData.pagination.hasPreviousPage}
+            currentSort={sort}
+            currentFilters={{
+              domains: params.domains,
+              tags: params.tags,
+            }}
+            currentParams={rawParams}
+          />
+        </Suspense>
+      </PageLayout>
     </SearchPageClient>
   );
 }

--- a/src/app/stats/page.tsx
+++ b/src/app/stats/page.tsx
@@ -10,7 +10,7 @@ import { DomainsTab } from '@/components/stats/domains-tab';
 import { TagsTab } from '@/components/stats/tags-tab';
 import { UsersTab } from '@/components/stats/users-tab';
 import { StatsTabsWrapper } from '@/components/stats/stats-tabs-wrapper';
-import { ThemeToggle } from '@/components/theme-toggle';
+import { PageLayout } from '@/components/page-layout';
 
 function TabSkeleton() {
   return (
@@ -23,20 +23,22 @@ function TabSkeleton() {
 
 export default function StatsPage() {
   return (
-    <div className="container mx-auto py-6 space-y-6">
-      <div className="flex items-center justify-between gap-2">
-        <h1 className="text-3xl font-bold">Bookmark Statistics</h1>
-        <div className="flex items-center gap-2">
-          <Link href="/search">
-            <Button variant="outline" size="sm">
-              <Search className="h-4 w-4 mr-2" />
-              Search
-            </Button>
-          </Link>
-          <ThemeToggle />
-        </div>
-      </div>
-      
+    <PageLayout
+      title={
+        <Link href="/stats" className="hover:underline">
+          Bookmark Statistics
+        </Link>
+      }
+      description="Analyze your bookmarking patterns and trends"
+      actions={
+        <Link href="/search">
+          <Button variant="outline" size="sm">
+            <Search className="h-4 w-4 mr-2" />
+            Search
+          </Button>
+        </Link>
+      }
+    >
       <StatsTabsWrapper>
         <TabsContent value="overview">
           <Suspense fallback={<TabSkeleton />}>
@@ -68,6 +70,6 @@ export default function StatsPage() {
           </Suspense>
         </TabsContent>
       </StatsTabsWrapper>
-    </div>
+    </PageLayout>
   );
 }

--- a/src/components/page-layout.tsx
+++ b/src/components/page-layout.tsx
@@ -1,0 +1,43 @@
+import { ReactNode } from 'react';
+import { ThemeToggle } from './theme-toggle';
+
+interface PageLayoutProps {
+  title: ReactNode;
+  description?: string;
+  actions?: ReactNode;
+  children: ReactNode;
+  hideThemeToggle?: boolean;
+}
+
+export function PageLayout({
+  title,
+  description,
+  actions,
+  children,
+  hideThemeToggle = false,
+}: PageLayoutProps) {
+  return (
+    <div className="flex flex-col gap-6 p-4 sm:p-6 lg:p-8 w-full">
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex flex-col gap-1">
+          <h2 className="text-2xl font-semibold tracking-tight">
+            {title}
+          </h2>
+          {description && (
+            <p className="text-muted-foreground">
+              {description}
+            </p>
+          )}
+        </div>
+        <div className="flex items-center gap-2">
+          {actions}
+          {!hideThemeToggle && <ThemeToggle />}
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-4">
+        {children}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Created a reusable `PageLayout` component to standardize page structure across the application
- Unified the layout for `/search`, `/stats`, and `/bookmarks/{id}` pages
- Improved navigation consistency by adding Search/Stats buttons to the bookmark detail page

## Changes
- **New component**: `src/components/page-layout.tsx` - A shared layout component that provides:
  - Consistent padding (`p-4 sm:p-6 lg:p-8`)
  - Standardized title styling (`text-2xl font-semibold tracking-tight`)
  - Optional description text with muted styling
  - Action buttons area with theme toggle
  
- **Updated pages**:
  - `/search`: Refactored to use PageLayout
  - `/stats`: Refactored to use PageLayout
  - `/bookmarks/{id}`: Refactored to use PageLayout and added navigation buttons

## Benefits
- Consistent visual design across all pages
- Easier maintenance with centralized layout logic
- Better user experience with consistent navigation patterns
- Reduced code duplication

## Test plan
- [x] Verify `/search` page renders correctly with the new layout
- [x] Verify `/stats` page renders correctly with the new layout
- [x] Verify `/bookmarks/{id}` page renders correctly with navigation buttons
- [x] Confirm theme toggle works on all pages
- [x] Test responsive behavior on different screen sizes
- [x] Run `pnpm typecheck` to ensure no TypeScript errors