### PR TITLE
Improve bookmark count display in search footer

### DIFF
--- a/src/components/bookmark-list.tsx
+++ b/src/components/bookmark-list.tsx
@@ -52,6 +52,19 @@ export function BookmarkList({
   currentFilters,
   currentParams,
 }: BookmarkListProps) {
+  // Check if any filters are active
+  const hasActiveFilters = 
+    (currentFilters.domains.length > 0) || 
+    (currentFilters.tags.length > 0) ||
+    currentParams.q ||
+    currentParams.selectedUsers ||
+    currentParams.dateRange;
+
+  // Format number with comma separators
+  const formatNumber = (num: number) => {
+    return num.toLocaleString();
+  };
+
   // Helper to build URL with current params
   const buildUrlWithParams = (cursor?: string) => {
     const params = new URLSearchParams();
@@ -228,7 +241,8 @@ export function BookmarkList({
 
         <div className="flex items-center justify-between px-2 py-3">
           <div className="flex-1 text-sm text-muted-foreground">
-          Showing {bookmarks.length} of {total} bookmark(s)
+            <span className="font-medium">{formatNumber(total)}</span> bookmark{total !== 1 ? 's' : ''}
+            {hasActiveFilters && <span className="ml-1 text-xs">(filtered)</span>}
           </div>
           <div className="flex items-center gap-2">
             <Link href={hasPreviousPage ? buildUrlWithParams() : '#'}>


### PR DESCRIPTION
## Summary
- Simplified the footer display from "Showing 25 of Y bookmark(s)" to just "Y bookmarks"
- Added proper number formatting with comma separators for better readability
- Shows "(filtered)" indicator when any filters are active

## Changes
- Replaced verbose pagination text with cleaner total count display
- Added `formatNumber()` function to format numbers with locale-appropriate separators
- Added `hasActiveFilters` check to detect when filters are applied
- Implemented proper singular/plural handling for bookmark count

## Why this change?
The previous "Showing 25 of Y" format was redundant since the page always displays 25 items (or less on the last page). The new format is more concise and focuses on the information users actually care about - the total number of bookmarks matching their search criteria.

## Screenshots
Before: `Showing 25 of 27523 bookmark(s)`
After: `27,523 bookmarks` (or `27,523 bookmarks (filtered)` when filters are active)