### PR TITLE
Fix: Add Number conversion for proper comma formatting in stats

### DIFF
--- a/src/app/actions/stats-actions.ts
+++ b/src/app/actions/stats-actions.ts
@@ -13,8 +13,8 @@ export async function getBookmarkStats() {
     .from(bookmarks);
 
   return {
-    totalBookmarks: stats[0]?.totalBookmarks || 0,
-    totalEntries: stats[0]?.totalDomains || 0, // Keep as totalEntries for backward compatibility
+    totalBookmarks: Number(stats[0]?.totalBookmarks) || 0,
+    totalEntries: Number(stats[0]?.totalDomains) || 0, // Keep as totalEntries for backward compatibility
   };
 }
 
@@ -31,7 +31,7 @@ export async function getDomainStats() {
 
   return domainStats.map(stat => ({
     domain: stat.domain!,
-    count: stat.count,
+    count: Number(stat.count),
   }));
 }
 
@@ -51,7 +51,7 @@ export async function getTagStats() {
   return tagStats.map(stat => ({
     id: stat.id,
     label: stat.label,
-    count: stat.count,
+    count: Number(stat.count),
   }));
 }
 
@@ -68,7 +68,7 @@ export async function getTimelineStats() {
 
   return timelineStats.map(stat => ({
     date: stat.date,
-    count: stat.count,
+    count: Number(stat.count),
   }));
 }
 
@@ -85,7 +85,7 @@ export async function getBookmarkGrowthStats() {
 
   return growthStats.map(stat => ({
     date: stat.date,
-    count: stat.count,
-    cumulative: stat.cumulative,
+    count: Number(stat.count),
+    cumulative: Number(stat.cumulative),
   }));
 }


### PR DESCRIPTION
## Summary
- Add `Number()` conversion to all stats functions to ensure proper comma formatting
- Fixes issue where numbers like 27525 were not displaying as 27,525

## Problem
PostgreSQL aggregate functions return string values even when the TypeScript type is specified as number. This causes `toLocaleString()` to not work properly since it's being called on strings.

## Solution
Convert all database results to numbers using `Number()` in:
- `getBookmarkStats()` - Total bookmarks and entries
- `getDomainStats()` - Domain counts
- `getTagStats()` - Tag counts  
- `getTimelineStats()` - Timeline data
- `getBookmarkGrowthStats()` - Growth statistics

## Test Plan
- [x] View stats page overview tab
- [x] Verify numbers show with comma separators (e.g., 27,525 instead of 27525)
- [x] Check all other tabs for consistent formatting