### PR TITLE
Add max-width constraint to improve layout on large screens

### DIFF
--- a/src/components/page-layout.tsx
+++ b/src/components/page-layout.tsx
@@ -17,7 +17,7 @@ export function PageLayout({
   hideThemeToggle = false,
 }: PageLayoutProps) {
   return (
-    <div className="flex flex-col gap-6 p-4 sm:p-6 lg:p-8 w-full">
+    <div className="flex flex-col gap-6 p-4 sm:p-6 lg:p-8 w-full max-w-7xl mx-auto">
       <div className="flex items-center justify-between gap-2">
         <div className="flex flex-col gap-1">
           <h2 className="text-2xl font-semibold tracking-tight">


### PR DESCRIPTION
## Summary
- Added `max-w-7xl mx-auto` to PageLayout component to constrain content width on large screens
- Improves readability by preventing content from stretching too wide on desktop displays
- Affects all pages using PageLayout: search, stats, and bookmark detail pages

## Changes
- Updated PageLayout component to include max-width of 1280px (max-w-7xl)
- Content is now centered with mx-auto
- Responsive design maintained for smaller screens

## Test plan
- [x] Verified search page layout on desktop
- [x] Verified stats page layout on desktop  
- [x] Verified bookmark detail page layout on desktop
- [x] Confirmed responsive behavior on mobile/tablet remains unchanged