### PR TITLE
feat: enhance search functionality with AND search and phrase search

### DIFF
--- a/src/app/actions/__tests__/bookmark-actions.integration.test.ts
+++ b/src/app/actions/__tests__/bookmark-actions.integration.test.ts
@@ -156,6 +156,64 @@ skipInCI('bookmark-actions integration tests', () => {
       expect(result.bookmarks).toHaveLength(0);
       expect(result.total).toBe(0);
     });
+
+    it('should support AND search with space-separated terms', async () => {
+      const filters: BookmarkFilters = {
+        searchQuery: 'React development',
+        selectedDomains: [],
+        selectedTags: [],
+        selectedUsers: [],
+      };
+
+      const result = await getBookmarks(filters);
+
+      expect(result.bookmarks).toHaveLength(1);
+      expect(result.bookmarks[0].entry?.title).toContain('React');
+      expect(result.bookmarks[0].entry?.summary).toContain('development');
+    });
+
+    it('should support phrase search with double quotes', async () => {
+      const filters: BookmarkFilters = {
+        searchQuery: '"React development"',
+        selectedDomains: [],
+        selectedTags: [],
+        selectedUsers: [],
+      };
+
+      const result = await getBookmarks(filters);
+
+      expect(result.bookmarks).toHaveLength(1);
+      expect(result.bookmarks[0].entry?.summary).toContain('React development');
+    });
+
+    it('should support mixed phrase and term search', async () => {
+      const filters: BookmarkFilters = {
+        searchQuery: '"Test Entry" interesting',
+        selectedDomains: [],
+        selectedTags: [],
+        selectedUsers: [],
+      };
+
+      const result = await getBookmarks(filters);
+
+      expect(result.bookmarks).toHaveLength(1);
+      expect(result.bookmarks[0].entry?.title).toBe('Another Test Entry');
+      expect(result.bookmarks[0].entry?.summary).toContain('interesting');
+    });
+
+    it('should require all terms in AND search', async () => {
+      const filters: BookmarkFilters = {
+        searchQuery: 'React JavaScript',
+        selectedDomains: [],
+        selectedTags: [],
+        selectedUsers: [],
+      };
+
+      const result = await getBookmarks(filters);
+
+      // Should not find any bookmarks because no single bookmark contains both "React" and "JavaScript" in text
+      expect(result.bookmarks).toHaveLength(0);
+    });
   });
 
   describe('domain filtering', () => {

--- a/src/lib/__tests__/search-query-parser.test.ts
+++ b/src/lib/__tests__/search-query-parser.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import { parseSearchQuery } from '../search-query-parser';
+
+describe('parseSearchQuery', () => {
+  it('should parse simple space-separated terms', () => {
+    const result = parseSearchQuery('claude code limit');
+    expect(result).toEqual({
+      phrases: [],
+      terms: ['claude', 'code', 'limit']
+    });
+  });
+
+  it('should parse double-quoted phrases', () => {
+    const result = parseSearchQuery('"claude code"');
+    expect(result).toEqual({
+      phrases: ['claude code'],
+      terms: []
+    });
+  });
+
+  it('should parse mixed queries with phrases and terms', () => {
+    const result = parseSearchQuery('"claude code" limit');
+    expect(result).toEqual({
+      phrases: ['claude code'],
+      terms: ['limit']
+    });
+  });
+
+  it('should parse multiple quoted phrases', () => {
+    const result = parseSearchQuery('"hello world" "foo bar" baz');
+    expect(result).toEqual({
+      phrases: ['hello world', 'foo bar'],
+      terms: ['baz']
+    });
+  });
+
+  it('should handle empty queries', () => {
+    const result = parseSearchQuery('');
+    expect(result).toEqual({
+      phrases: [],
+      terms: []
+    });
+  });
+
+  it('should handle queries with only spaces', () => {
+    const result = parseSearchQuery('   ');
+    expect(result).toEqual({
+      phrases: [],
+      terms: []
+    });
+  });
+
+  it('should handle quotes within terms', () => {
+    const result = parseSearchQuery('test "quoted phrase" more');
+    expect(result).toEqual({
+      phrases: ['quoted phrase'],
+      terms: ['test', 'more']
+    });
+  });
+
+  it('should handle multiple spaces between terms', () => {
+    const result = parseSearchQuery('claude    code    limit');
+    expect(result).toEqual({
+      phrases: [],
+      terms: ['claude', 'code', 'limit']
+    });
+  });
+
+  it('should handle leading and trailing spaces', () => {
+    const result = parseSearchQuery('  claude code  ');
+    expect(result).toEqual({
+      phrases: [],
+      terms: ['claude', 'code']
+    });
+  });
+
+  it('should handle unclosed quotes by treating them as regular text', () => {
+    const result = parseSearchQuery('"unclosed quote');
+    expect(result).toEqual({
+      phrases: [],
+      terms: ['"unclosed', 'quote']
+    });
+  });
+
+  it('should handle complex queries', () => {
+    const result = parseSearchQuery('search "exact phrase" and "another phrase" with terms');
+    expect(result).toEqual({
+      phrases: ['exact phrase', 'another phrase'],
+      terms: ['search', 'and', 'with', 'terms']
+    });
+  });
+
+  it('should handle empty quotes', () => {
+    const result = parseSearchQuery('test "" empty');
+    expect(result).toEqual({
+      phrases: [''],
+      terms: ['test', 'empty']
+    });
+  });
+});

--- a/src/lib/search-query-parser.ts
+++ b/src/lib/search-query-parser.ts
@@ -1,0 +1,44 @@
+export interface ParsedSearchQuery {
+  phrases: string[];  // Double-quoted phrases
+  terms: string[];    // Individual search terms
+}
+
+export function parseSearchQuery(query: string): ParsedSearchQuery {
+  const phrases: string[] = [];
+  const terms: string[] = [];
+  
+  // Extract double-quoted phrases (including empty quotes)
+  const phraseRegex = /"([^"]*)"/g;
+  let match;
+  const usedIndices = new Set<number>();
+  
+  while ((match = phraseRegex.exec(query)) !== null) {
+    phrases.push(match[1]);
+    // Record indices of matched parts
+    for (let i = match.index; i < match.index + match[0].length; i++) {
+      usedIndices.add(i);
+    }
+  }
+  
+  // Process parts outside double quotes
+  let currentTerm = '';
+  for (let i = 0; i < query.length; i++) {
+    if (!usedIndices.has(i)) {
+      if (query[i] === ' ') {
+        if (currentTerm.trim()) {
+          terms.push(currentTerm.trim());
+        }
+        currentTerm = '';
+      } else {
+        currentTerm += query[i];
+      }
+    }
+  }
+  
+  // Add the last term
+  if (currentTerm.trim()) {
+    terms.push(currentTerm.trim());
+  }
+  
+  return { phrases, terms };
+}


### PR DESCRIPTION
## Summary
- Add support for space-separated AND search to find bookmarks containing all terms
- Add support for double-quoted phrase search for exact phrase matching
- Implement a search query parser to handle mixed queries with both phrases and terms

## Changes
- Created `search-query-parser.ts` to parse search queries into phrases and individual terms
- Updated `bookmark-actions.ts` to use AND logic for multiple search terms
- Added comprehensive unit tests for the search query parser
- Added integration tests for the new search features

## Examples
- `claude code limit` - finds bookmarks containing ALL three words
- `"claude code"` - finds bookmarks containing the exact phrase "claude code"
- `"claude code" limit` - finds bookmarks containing the phrase "claude code" AND the word "limit"

## Test plan
- [x] Unit tests for search query parser pass
- [x] Integration tests for new search functionality pass
- [x] Lint checks pass
- [x] TypeScript type checking passes