### PR TITLE
Improve network refresh UX with visual feedback

### DIFF
--- a/src/components/network-refresh-manager.tsx
+++ b/src/components/network-refresh-manager.tsx
@@ -5,13 +5,14 @@ import { usePageVisibility } from "@/hooks/usePageVisibility";
 import { useRouter } from "next/navigation";
 import { useCallback, useRef } from "react";
 import { toast } from "sonner";
+import { RefreshCw } from "lucide-react";
 
 export function NetworkRefreshManager() {
   const router = useRouter();
   const lastRefreshRef = useRef<number>(Date.now());
   const REFRESH_COOLDOWN = 10000; // 10 seconds cooldown between refreshes
 
-  const performRefresh = useCallback((message: string) => {
+  const performRefresh = useCallback(() => {
     const now = Date.now();
     const timeSinceLastRefresh = now - lastRefreshRef.current;
     
@@ -22,8 +23,14 @@ export function NetworkRefreshManager() {
     
     lastRefreshRef.current = now;
     
-    // Show toast notification
-    toast.success(message);
+    // Show toast notification with spinning refresh icon
+    toast.custom((t) => (
+      <div className="flex items-center gap-2 px-4 py-3 bg-white dark:bg-gray-800 rounded-lg shadow-md">
+        <RefreshCw className="w-4 h-4 animate-spin text-blue-600 dark:text-blue-400" />
+      </div>
+    ), {
+      duration: 2000,
+    });
     
     // Refresh the current route data
     router.refresh();
@@ -38,11 +45,11 @@ export function NetworkRefreshManager() {
   }, [router]);
 
   const handleReconnect = useCallback(() => {
-    performRefresh("ネットワークに再接続しました。ページを更新します...");
+    performRefresh();
   }, [performRefresh]);
 
   const handlePageVisible = useCallback(() => {
-    performRefresh("ページを更新しています...");
+    performRefresh();
   }, [performRefresh]);
 
   // Handle network reconnection


### PR DESCRIPTION
## Summary
- Replace text-based loading messages with a clean spinning refresh icon
- Remove Japanese text "ページを更新しています..." from toast notifications
- Provide consistent visual feedback across the app

## Changes
- Updated `NetworkRefreshManager` component to show a spinning `RefreshCw` icon instead of text
- Toast notification now displays only the animated icon for 2 seconds
- Consistent with other loading states in the app (e.g., markdown refresh button)

## Benefits
- Cleaner, more modern UX without text clutter
- Language-agnostic visual feedback
- Better consistency with the app's design system