### PR TITLE
chore: group Renovate updates by dependency type

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,17 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:best-practices"
+  ],
+  "packageRules": [
+    {
+      "groupName": "dependencies (non-major)",
+      "matchDepTypes": ["dependencies"],
+      "matchUpdateTypes": ["minor", "patch"]
+    },
+    {
+      "groupName": "devDependencies (non-major)",
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["minor", "patch"]
+    }
   ]
 }


### PR DESCRIPTION
## Summary

Configure Renovate to group minor and patch updates by dependency type, reducing PR noise.

## Changes

- Added `packageRules` to group minor/patch updates for `dependencies`
- Added `packageRules` to group minor/patch updates for `devDependencies`
- Major updates continue to be created as individual PRs

## Benefits

- **Reduced PR volume**: Instead of individual PRs for each minor/patch update, Renovate will create:
  - One PR for all non-major `dependencies` updates
  - One PR for all non-major `devDependencies` updates
- **Easier review**: Related updates grouped together
- **Less notification noise**: Fewer PRs to review and merge

## Test plan

- [x] Validate renovate.json syntax
- [ ] Monitor Renovate behavior in next run
- [ ] Verify grouped PRs are created as expected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to organize routine updates into separate groups for improved management efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->