### PR TITLE
chore: group @types/* updates with definitelyTyped preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:best-practices"
+    "config:best-practices",
+    "group:definitelyTyped"
   ],
   "packageRules": [
     {


### PR DESCRIPTION
## Summary

Add `group:definitelyTyped` preset to group all `@types/*` package updates into a single PR.

## Changes

- Added `group:definitelyTyped` to the extends array in renovate.json

## Benefits

- **Further reduced PR noise**: All TypeScript type definition updates (`@types/*`) will be grouped into one PR
- **Easier review**: Related type definition updates reviewed together
- **Consistent with existing strategy**: Complements the existing dependency grouping rules

## Example

Instead of individual PRs for:
- `@types/node`
- `@types/react`
- `@types/react-dom`

Renovate will create a single PR containing all `@types/*` updates.

## Test plan

- [x] Validate renovate.json syntax
- [ ] Monitor Renovate behavior in next run
- [ ] Verify @types/* updates are grouped as expected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Renovate configuration to include DefinitelyTyped package updates in the dependency grouping strategy, enhancing the update management alongside existing best-practices guidelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->